### PR TITLE
Fixed permissions on file /etc/ceph/ceph.client.admin.keyring

### DIFF
--- a/openattic-dev/opensuse_leap_42.2/entrypoint.sh
+++ b/openattic-dev/opensuse_leap_42.2/entrypoint.sh
@@ -98,6 +98,7 @@ cfg_file=/etc/icinga/objects/openattic_static.cfg' \
   chown -R openattic:openattic /var/lib/openattic
 
   chgrp -R openattic /etc/ceph
+  chmod 644 /etc/ceph/ceph.client.admin.keyring
 
   systemd --system &> systemd.log &
   SYSD_PID=$!


### PR DESCRIPTION
Fixed permissions on file /etc/ceph/ceph.client.admin.keyring

Signed-off-by: Ricardo Marques <rimarques@suse.com>