### PR TITLE
npm install should run with openattic user (non root user)

### DIFF
--- a/openattic-dev/opensuse_leap_42.2/entrypoint.sh
+++ b/openattic-dev/opensuse_leap_42.2/entrypoint.sh
@@ -112,8 +112,16 @@ cfg_file=/etc/icinga/objects/openattic_static.cfg' \
   /srv/openattic/bin/oaconfig install --allow-broken-hostname
   chmod 660 /var/log/openattic/openattic.log
   cd /srv/openattic/webui
-  npm install
-  bower install --allow-root
+  touch .chown
+  chown openattic .chown &> /dev/null
+  CHOWN_RET=$?
+  if [ "$CHOWN_RET" == "0" ]; then
+    npm install
+    bower install --allow-root
+  else
+    runuser -l openattic -c 'cd /srv/openattic/webui && npm install && bower install'
+  fi
+  rm .chown
   grunt dev
 }
 

--- a/openattic-dev/ubuntu_16.04/entrypoint.sh
+++ b/openattic-dev/ubuntu_16.04/entrypoint.sh
@@ -63,8 +63,16 @@ function setup_oa {
   a2enconf openattic
   systemctl restart apache2
   cd /srv/openattic/webui
-  npm install
-  bower install --allow-root
+  touch .chown
+  chown openattic .chown &> /dev/null
+  CHOWN_RET=$?
+  if [ "$CHOWN_RET" == "0" ]; then
+    npm install
+    bower install --allow-root
+  else
+    runuser -l openattic -c 'cd /srv/openattic/webui && npm install && bower install'
+  fi
+  rm .chown
   grunt dev
 }
 


### PR DESCRIPTION
This will prevent the error "EPERM: operation not permitted, chown '/srv/openattic/webui/node_modules/grunt-contrib-copy/package.json'" when running npm install

Signed-off-by: Ricardo Marques <rimarques@suse.com>