### PR TITLE
openattic-dev: support for running django unit tests

### DIFF
--- a/openattic-dev/README.md
+++ b/openattic-dev/README.md
@@ -4,6 +4,8 @@ This docker image will run openATTIC from the source. It will spawn all the
 necessary services such as apache, postgresql, nagios/icinga, pnp4nagios, and
 is already ready for managing a Ceph cluster.
 
+You can also run the openATTIC django unit tests using this image.
+
 Please choose which distro you want to use for running openATTIC, a execute
 the instructions below inside the distro directory.
 
@@ -17,7 +19,7 @@ the instructions below inside the distro directory.
 
 * Clone the bitbucket openattic repo
 `hg clone https://bitbucket.org/openattic/openattic`
- 
+
 * Assuming openattic repo is located in `/home/oa/openattic` and the Ceph
 configuration and keyring files are located in `/etc/ceph`, run the following
 command:
@@ -44,6 +46,27 @@ will keep running nevertheless.
 
 * To check the openAttic backend log run the following command:
 `docker exec CONTAINER_ID tail -f /var/log/openattic/openattic.log`
+
+### Running the django unit tests
+
+* Clone the bitbucket openattic repo
+`hg clone https://bitbucket.org/openattic/openattic`
+
+* Assuming openattic repo is located in `/home/oa/openattic`:
+```
+docker run -t -v /home/oa/openattic:/srv/openattic \
+		      -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
+		      --net=host --privileged \
+		      --security-opt seccomp=unconfined \
+		      --stop-signal=SIGRTMIN+3 \
+		      --tmpfs /run/lock --rm \
+		      openattic-dev tests
+```
+This is will start a container that will run the django unit tests using the
+source code present in `/home/oa/openattic`.
+
+This container is removed automatically when it finishes the execution of the
+unit tests.
 
 
 ## HTTP proxy

--- a/openattic-dev/opensuse_leap_42.2/Dockerfile
+++ b/openattic-dev/opensuse_leap_42.2/Dockerfile
@@ -6,8 +6,10 @@ MAINTAINER Ricardo Dias "rdias@suse.com"
 ADD entrypoint.sh pgsql_setup.sh /
 
 RUN zypper ar http://download.opensuse.org/repositories/filesystems:/openATTIC/openSUSE_Leap_42.2 oa_repo
+RUN zypper ar http://download.opensuse.org/repositories/filesystems/openSUSE_Leap_42.2 zfs_repo
 RUN zypper --gpg-auto-import-keys ref && \
 zypper -n install --force-resolution krb5 && \
+zypper -n install --force-resolution e2fsprogs && \
 zypper -n install mercurial git nodejs npm bridge-utils bzip2 dbus-1 systemd \\
 python-django=1.6.11 \\
 python-django-filter python-djangorestframework python-djangorestframework-bulk python-M2Crypto memcached \\
@@ -20,7 +22,7 @@ python-rados ceph-common cronie lvm2 bc nagios icinga \\
 pnp4nagios nagios-plugins-http nagios-plugins-swap nagios-plugins-ssh \\
 nagios-plugins-ping nagios-plugins-disk nagios-plugins-users nagios-plugins-procs \\
 nagios-plugins-load nagios-plugins-tcp nfs-utils cron postgresql-server \\
-postgresql vlan shadow smtp_daemon samba && \\
+postgresql vlan shadow smtp_daemon samba python-mock zfs && \\
 zypper clean -a
 
 RUN (cd /usr/lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == \

--- a/openattic-dev/opensuse_leap_42.2/entrypoint.sh
+++ b/openattic-dev/opensuse_leap_42.2/entrypoint.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-: ${PGSQL_IP:=*}
-
 function setup_oa {
   mkdir -p /var/log/openattic
   mkdir -p /etc/openattic/databases
@@ -117,8 +115,122 @@ cfg_file=/etc/icinga/objects/openattic_static.cfg' \
   grunt dev
 }
 
+function run_oa_tests {
+  mkdir -p /var/log/openattic
+  mkdir -p /etc/openattic/databases
+  mkdir -p /var/lock/openattic
+  mkdir -p /var/lib/openattic
+
+  cp /srv/openattic/etc/systemd/* /usr/lib/systemd/system/
+  cp /srv/openattic/etc/cron.d/updatetwraid /etc/cron.d
+  cp /srv/openattic/etc/dbus-1/system.d/openattic.conf /etc/dbus-1/system.d
+  cp /srv/openattic/etc/logrotate.d/openattic /etc/logrotate.d
+  cp /srv/openattic/debian/database_install/pgsql_template.ini /etc/openattic/databases/pgsql.ini
+  ln -s /etc/openattic/databases/pgsql.ini /etc/openattic/database.ini
+
+  cp /srv/openattic/rpm/sysconfig/openattic.SUSE /var/adm/fillup-templates/sysconfig.openattic
+  cp /srv/openattic/etc/tmpfiles.d/openattic.conf /usr/lib/tmpfiles.d/
+  cp /srv/openattic/rpm/sysconfig/openattic.SUSE /etc/sysconfig/openattic
+
+
+cat > /etc/default/openattic <<EOF
+PYTHON="/usr/bin/python"
+OADIR="/srv/openattic/backend"
+
+RPCD_PIDFILE="/var/run/openattic_rpcd.pid"
+RPCD_CHUID="openattic:openattic"
+RPCD_LOGFILE="/var/log/openattic/openattic_rpcd.log"
+RPCD_LOGLEVEL="INFO"
+RPCD_OPTIONS="$OADIR/manage.py runrpcd"
+RPCD_CERTFILE=""
+RPCD_KEYFILE=""
+
+SYSD_PIDFILE="/var/run/openattic_systemd.pid"
+SYSD_LOGFILE="/var/log/openattic/openattic_systemd.log"
+SYSD_LOGLEVEL="INFO"
+SYSD_OPTIONS="$OADIR/manage.py runsystemd"
+
+WEBSERVER_SERVICE="apache2"
+SAMBA_SERVICES="smb nmb"
+WINBIND_SERVICE="winbind"
+
+NAGIOS_CFG="/etc/nagios/nagios.cfg"
+NAGIOS_STATUS_DAT="/var/log/nagios/status.dat"
+NAGIOS_SERVICE="nagios"
+NPCD_MOD="/usr/lib64/npcdmod.o"
+NPCD_CFG="/etc/pnp4nagios/npcd.cfg"
+NPCD_SERVICE="npcd"
+EOF
+
+  # NAGIOS
+  cp /srv/openattic/etc/nagios-plugins/config/openattic.cfg /etc/icinga/objects/openattic_plugins.cfg
+  echo >> /etc/icinga/objects/openattic_plugins.cfg
+  cat /srv/openattic/etc/nagios-plugins/config/openattic-ceph.cfg >> /etc/icinga/objects/openattic_plugins.cfg
+
+  cp /srv/openattic/etc/nagios3/conf.d/openattic_*.cfg /etc/icinga/objects/
+
+  cp /srv/openattic/backend/nagios/plugins/check_diskstats /usr/lib/nagios/plugins
+  cp /srv/openattic/backend/nagios/plugins/check_oa_utilization /usr/lib/nagios/plugins
+  cp /srv/openattic/backend/nagios/plugins/check_iface_traffic /usr/lib/nagios/plugins
+  cp /srv/openattic/backend/nagios/plugins/check_openattic_rpcd /usr/lib/nagios/plugins
+  cp /srv/openattic/backend/nagios/plugins/check_openattic_systemd /usr/lib/nagios/plugins
+  cp /srv/openattic/backend/nagios/plugins/check_lvm_snapshot /usr/lib/nagios/plugins
+  cp /srv/openattic/backend/nagios/plugins/check_cputime /usr/lib/nagios/plugins
+  cp /srv/openattic/backend/nagios/plugins/check_protocol_traffic /usr/lib/nagios/plugins
+  cp /srv/openattic/backend/nagios/plugins/check_twraid_unit /usr/lib/nagios/plugins
+  cp /srv/openattic/backend/nagios/plugins/notify_openattic /usr/lib/nagios/plugins
+  cp /srv/openattic/backend/nagios/plugins/check_ceph* /usr/lib/nagios/plugins
+  cp -r /srv/openattic/etc/pnp4nagios/check_commands /etc/pnp4nagios/
+
+
+  sed -i 's!^OADIR=.*!OADIR="/srv/openattic/backend"!' /etc/sysconfig/openattic
+  sed -i -e 's/^name.*/name = openattic/g' \
+         -e 's/^user.*/user = openattic/g' \
+         -e 's/^password.*/password = openattic/g' \
+         -e 's/^host.*/host = localhost/g' \
+         -e 's/^port.*/port = 5432/g' \
+         /etc/openattic/databases/pgsql.ini
+
+  sed -i '/^# You can specify individual object/a \
+          cfg_file=/etc/icinga/objects/openattic_plugins.cfg\
+          cfg_file=/etc/icinga/objects/openattic_static.cfg' \
+          /etc/icinga/icinga.cfg
+
+
+
+  chown -R openattic:openattic /var/log/openattic
+  chown -R openattic:openattic /etc/openattic
+  chown -R openattic:openattic /var/lock/openattic
+  chown -R openattic:openattic /var/lib/openattic
+
+  chgrp -R openattic /etc/ceph
+
+  systemd --system &> systemd.log &
+  SYSD_PID=$!
+  sleep 3
+  systemctl daemon-reload
+  systemctl stop apache2
+  systemctl start icinga
+  systemctl start npcd
+  systemd-tmpfiles --create /usr/lib/tmpfiles.d/openattic.conf
+  systemctl start lvm2-lvmetad.socket
+  /srv/openattic/bin/oaconfig install --allow-broken-hostname
+  chmod 660 /var/log/openattic/openattic.log
+  systemctl stop apache2
+
+  cd /srv/openattic/backend
+  python manage.py test -v 2
+}
+
+
 case "$1" in
-  setup_oa | *)
+  setup_oa)
+    setup_oa
+    ;;
+  tests)
+    run_oa_tests
+    ;;
+  *)
     setup_oa
     ;;
 esac

--- a/openattic-dev/ubuntu_16.04/Dockerfile
+++ b/openattic-dev/ubuntu_16.04/Dockerfile
@@ -13,8 +13,13 @@ python-configobj python-gobject python-pam python-m2crypto python-netifaces \
 python-netaddr python-requests python-pyudev python-djangorestframework \
 lsb-release memcached python-memcache python-psycopg2 python-numpy \
 python-rtslib python-apt nagios3-core nagios-plugins-standard \
-nagios-plugins-basic rrdtool lvm2 ceph ceph-common python-ceph && \
+nagios-plugins-basic rrdtool lvm2 ceph ceph-common python-ceph \
+zfs && \
 apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN wget https://bootstrap.pypa.io/get-pip.py && \
+python get-pip.py && \
+/usr/local/bin/pip install mock
 
 RUN ln -s /usr/bin/nodejs /usr/bin/node
 RUN npm install -g bower

--- a/openattic-dev/ubuntu_16.04/entrypoint.sh
+++ b/openattic-dev/ubuntu_16.04/entrypoint.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-: ${PGSQL_IP:=*}
-
 function setup_oa {
   mkdir -p /var/log/openattic
   mkdir -p /etc/openattic/databases
@@ -68,8 +66,80 @@ function setup_oa {
   grunt dev
 }
 
+function run_oa_tests {
+  mkdir -p /var/log/openattic
+  mkdir -p /etc/openattic/databases
+  mkdir -p /var/lock/openattic
+
+  cp /srv/openattic/etc/systemd/* /lib/systemd/system/
+  cp /srv/openattic/etc/apache2/conf-available/openattic.conf /etc/apache2/conf-available
+  cp /srv/openattic/etc/dbus-1/system.d/openattic.conf /etc/dbus-1/system.d
+  cp /srv/openattic/etc/logrotate.d/openattic /etc/logrotate.d
+  cp /srv/openattic/etc/init.d/openattic-* /etc/init.d/
+  cp /srv/openattic/debian/default/openattic /etc/default
+  cp /srv/openattic/debian/database_install/pgsql_template.ini /etc/openattic/databases/pgsql.ini
+  ln -s /etc/openattic/databases/pgsql.ini /etc/openattic/database.ini
+
+  # NAGIOS
+  cp /srv/openattic/etc/nagios3/conf.d/openattic_static.cfg /etc/nagios3/conf.d
+  cp /srv/openattic/etc/nagios3/conf.d/openattic_contacts.cfg /etc/nagios3/conf.d
+  cp /srv/openattic/etc/nagios-plugins/config/*.cfg /etc/nagios-plugins/config
+  cp /srv/openattic/backend/nagios/plugins/check_diskstats /usr/lib/nagios/plugins
+  cp /srv/openattic/backend/nagios/plugins/check_oa_utilization /usr/lib/nagios/plugins
+  cp /srv/openattic/backend/nagios/plugins/check_iface_traffic /usr/lib/nagios/plugins
+  cp /srv/openattic/backend/nagios/plugins/check_openattic_rpcd /usr/lib/nagios/plugins
+  cp /srv/openattic/backend/nagios/plugins/check_openattic_systemd /usr/lib/nagios/plugins
+  cp /srv/openattic/backend/nagios/plugins/check_lvm_snapshot /usr/lib/nagios/plugins
+  cp /srv/openattic/backend/nagios/plugins/check_cputime /usr/lib/nagios/plugins
+  cp /srv/openattic/backend/nagios/plugins/check_protocol_traffic /usr/lib/nagios/plugins
+  cp /srv/openattic/backend/nagios/plugins/check_twraid_unit /usr/lib/nagios/plugins
+  cp /srv/openattic/backend/nagios/plugins/notify_openattic /usr/lib/nagios/plugins
+  cp /srv/openattic/backend/nagios/plugins/check_ceph* /usr/lib/nagios/plugins
+  cp -r /srv/openattic/etc/pnp4nagios/check_commands /etc/pnp4nagios/
+
+
+  sed -i 's!^OADIR=.*!OADIR="/srv/openattic/backend"!' /etc/default/openattic
+  sed -i -e 's/^name.*/name = openattic/g' \
+         -e 's/^user.*/user = openattic/g' \
+         -e 's/^password.*/password = openattic/g' \
+         -e 's/^host.*/host = localhost/g' \
+         -e 's/^port.*/port = 5432/g' \
+         /etc/openattic/databases/pgsql.ini
+
+  sed -i -e 's!/usr/share/openattic!/srv/openattic/backend!g' \
+         /etc/apache2/conf-available/openattic.conf
+  echo "<Directory /srv/openattic>" >> /etc/apache2/conf-available/openattic.conf
+  echo "    Require all granted" >> /etc/apache2/conf-available/openattic.conf
+  echo "</Directory>" >> /etc/apache2/conf-available/openattic.conf
+
+  chown -R openattic:openattic /var/log/openattic
+  chown -R openattic:openattic /etc/openattic
+  chown -R openattic:openattic /var/lock/openattic
+
+  chgrp -R openattic /etc/ceph
+
+  systemd --system &> systemd.log &
+  SYSD_PID=$!
+  sleep 3
+  systemctl daemon-reload
+  systemctl start lvm2-lvmetad.socket
+  /srv/openattic/bin/oaconfig install --allow-broken-hostname
+  a2enconf openattic
+  systemctl stop apache2
+
+  cd /srv/openattic/backend
+  python manage.py test -v 2
+}
+
+
 case "$1" in
-  setup_oa | *)
+  setup_oa)
+    setup_oa
+    ;;
+  tests)
+    run_oa_tests
+    ;;
+  *)
     setup_oa
     ;;
 esac


### PR DESCRIPTION
This PR adds the support to run openATTIC django unit tests in both Ubuntu and openSUSE distros.

Signed-off-by: Ricardo Dias <rdias@suse.com>