### PR TITLE
Fixed SALT_API_SHARED_SECRET in /etc/sysconfig/openattic

### DIFF
--- a/openattic-dev/opensuse_leap_42.3/entrypoint.sh
+++ b/openattic-dev/opensuse_leap_42.3/entrypoint.sh
@@ -54,7 +54,7 @@ function setup_oa {
   /srv/openattic/bin/oaconfig install --allow-broken-hostname
 
   if [[ $1 != "" ]]; then
-    echo "SALT_API_SHARED_SECRET=\"$1\"" >> /etc/sysconfig/openattic
+    sed -i -r "s/#?SALT_API_SHARED_SECRET.*/SALT_API_SHARED_SECRET=\"$1\"/" /etc/sysconfig/openattic
   fi
 
   chmod 660 /var/log/openattic/openattic.log


### PR DESCRIPTION
With oA 3.5.3, the `SALT_API_SHARED_SECRET` already exist, thus we have to make sure, we replace it properly